### PR TITLE
remove `global` from userscripts

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -62,7 +62,7 @@ import { existsSync, readdirSync, mkdirSync, writeFileSync, readFileSync } from 
       },
     ];
 
-    const userscriptJS = `export default async function ({ addon, msg, global, console }) {\n\n}\n`;
+    const userscriptJS = `export default async function ({ addon, msg, console }) {\n\n}\n`;
     writeFileSync(dir + sep + "userscript.js", userscriptJS);
   }
   if (userstyleMatch) {


### PR DESCRIPTION
Removes `global` from userscripts.
See scratchaddons/scratchaddons#5276, scratchaddons/scratchaddons#5279